### PR TITLE
🔒 [security fix] Remove PII from logs

### DIFF
--- a/pkg/platform/telegram.go
+++ b/pkg/platform/telegram.go
@@ -130,7 +130,7 @@ func (t *Telegram) Translate(body []byte) (def.SessionData, error) {
 		env.User.Type = def.TYPE_INDIVIDUAL
 	}
 
-	log.Printf("User: %s %s | %s : %s", env.User.Firstname, env.User.Lastname, env.User.Username, env.User.Id)
+	log.Printf("User: %s", env.User.Id)
 
 	tokens := strings.Split(data.Message.Text, " ")
 	if len(tokens) > 0 && strings.HasPrefix(tokens[0], "/") {
@@ -142,7 +142,7 @@ func (t *Telegram) Translate(body []byte) (def.SessionData, error) {
 
 	env.Channel = strconv.Itoa(data.Message.Chat.Id)
 
-	log.Printf("Message: %s | %s", env.Msg.Command, env.Msg.Message)
+	log.Printf("Message: %s", env.Msg.Command)
 
 	return env, nil
 }
@@ -256,7 +256,7 @@ func PostTelegramMessage(data []byte, telegramId string) bool {
 		defer res.Body.Close()
 	}
 
-	log.Printf("Posted message %s, response %v", string(data), res)
+	log.Printf("Posted message, response %v", res)
 	return true
 }
 


### PR DESCRIPTION
This PR addresses a security vulnerability where PII was being exposed in application logs.

🎯 **What:** The vulnerability fixed is the logging of sensitive user details (Firstname, Lastname, Username), full message text, and full JSON payloads in `pkg/platform/telegram.go`.
⚠️ **Risk:** If logs are compromised or accessible to unauthorized personnel, sensitive user information and private message contents could be leaked, leading to privacy violations or targeted attacks.
🛡️ **Solution:** Modified the `log.Printf` statements to only include non-sensitive information:
- User logs now only include the User ID.
- Message logs now only include the command name.
- Post logs now only include the response status from the Telegram API, without the original request payload.

---
*PR created automatically by Jules for task [945593048252788031](https://jules.google.com/task/945593048252788031) started by @julwrites*